### PR TITLE
update for latest ui archive structure

### DIFF
--- a/tasks/install-ui.yml
+++ b/tasks/install-ui.yml
@@ -7,7 +7,7 @@
 - name: copy and unpack
   unarchive: >
     src={{ consul_download_folder }}/{{ consul_ui_archive }}
-    dest={{ consul_home }}
+    dest={{ consul_ui_dir }}
     copy=no
   when: consul_ui_was_downloaded|changed
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -39,6 +39,7 @@
     - "{{ consul_home }}/bin"
     - "{{ consul_data_dir }}"
     - "{{ consul_config_dir }}"
+    - "{{ consul_ui_dir }}"
 
 - name: copy and unpack
   unarchive: >


### PR DESCRIPTION
The consul ui archive structure no longer includes the dist dir.  This change creates the dist directory and unpacks to /opt/consul/dist
